### PR TITLE
Create index.js file for main node exports.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var encoding = require("./lib/encoding.js");
+
+module.exports = {
+  TextEncoder: encoding.TextEncoder,
+  TextDecoder: encoding.TextDecoder,
+  Indexes: require("./lib/encoding-indexes.js")
+};

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "stringencoding",
   "author": "Joshua Bell <inexorabletash@gmail.com>",
   "contributors": [
-    "Rick Eyre <rick.eyre@outlook.com"
+    "Rick Eyre <rick.eyre@outlook.com>"
   ],
   "version": "0.0.0",
   "description": "Polyfill for the Encoding Living Standard's API.",
-  "main": "encoding.js",
+  "main": "index.js",
   "files": [
-    "encoding.js",
-    "encoding-indexes.js"
+    "index.js",
+    "lib/encoding.js",
+    "lib/encoding-indexes.js"
   ],
   "repository": {
     "type": "git",
@@ -17,7 +18,8 @@
   },
   "keywords": [
     "encoding",
-    "decoding"
+    "decoding",
+    "living standard"
   ],
   "bugs": {
     "url": "https://github.com/inexorabletash/stringencoding/issues"


### PR DESCRIPTION
Also fix up some of the values in package.json to reflect changes.

I think with this we may be ready to register `stringencoding` on npm. @inexorabletash would you like to do that?

I don't think exporting `encoding-indexes.js` like this will do much though since we would have to include them on TextEncoder/Decoder's global before we require them. I think the only way to get around that problem would be to add `nodejs` specific code to `encoding.js` to require it if it's in node and attach it to `this`. Another solution would be to change the library a little to be able to pass in a specific index to the decoder's or encoder's constructor.
