### PR TITLE
"encoding.js" should require "encoding-indexes.js" if we're in Node.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,5 +3,4 @@ var encoding = require("./lib/encoding.js");
 module.exports = {
   TextEncoder: encoding.TextEncoder,
   TextDecoder: encoding.TextDecoder,
-  Indexes: require("./lib/encoding-indexes.js")
 };

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,3 +1,8 @@
+// If we're in node require encoding-indexes and attach it to the global.
+if (typeof module !== "undefined" && module.exports) {
+  this["encoding-indexes"] = require("./encoding-indexes.js")["encoding-indexes"];
+}
+
 (function(global) {
   'use strict';
 


### PR DESCRIPTION
I'm not sure if you're comfortable with a change like this to `encoding.js`.
