### PR TITLE
Change URLs for repo to reflect name changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/inexorabletash/stringencoding.git"
+    "url": "https://github.com/inexorabletash/text-encoding.git"
   },
   "keywords": [
     "encoding",
@@ -22,7 +22,7 @@
     "living standard"
   ],
   "bugs": {
-    "url": "https://github.com/inexorabletash/stringencoding/issues"
+    "url": "https://github.com/inexorabletash/text-encoding/issues"
   },
-  "homepage": "https://github.com/inexorabletash/stringencoding"
+  "homepage": "https://github.com/inexorabletash/text-encoding"
 }


### PR DESCRIPTION
This should be updated now that the GitHub URL is different.
