### PR TITLE
Make it possible to google closure advanced-compile encoding.js

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -711,9 +711,9 @@ if (typeof module !== "undefined" && module.exports) {
   var name_to_encoding = {};
   var label_to_encoding = {};
   encodings.forEach(function(category) {
-    category.encodings.forEach(function(encoding) {
-      name_to_encoding[encoding.name] = encoding;
-      encoding.labels.forEach(function(label) {
+    category['encodings'].forEach(function(encoding) {
+      name_to_encoding[encoding['name']] = encoding;
+      encoding['labels'].forEach(function(label) {
         label_to_encoding[label] = encoding;
       });
     });
@@ -1192,10 +1192,10 @@ if (typeof module !== "undefined" && module.exports) {
     if (!('encoding-indexes' in global))
       return;
     encodings.forEach(function(category) {
-      if (category.heading !== 'Legacy single-byte encodings')
+      if (category['heading'] !== 'Legacy single-byte encodings')
         return;
-      category.encodings.forEach(function(encoding) {
-        var idx = index(encoding.name);
+      category['encodings'].forEach(function(encoding) {
+        var idx = index(encoding['name']);
         /** @param {{fatal: boolean}} options */
         encoding.getDecoder = function(options) {
           return new SingleByteDecoder(idx, options);


### PR DESCRIPTION
The encoding description objects are defined with string-quoted-keys but accessed with dot-property syntax. This makes it impossible to [compile with google closure in advanced mode](https://developers.google.com/closure/compiler/docs/api-tutorial3#propnames). This patch uses angle-bracket syntax instead.

Note that this patch is necessary, but might not be sufficient, to compile in advanced mode.
