### PR TITLE
add non polyfill CustomTextEncoder and CustomTextDecoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+text-encoding.iml

--- a/README.md
+++ b/README.md
@@ -91,7 +91,13 @@ var uint8array = new TextEncoder(
 
 But note that the above won't work if you're using the polyfill in a browser that
 natively supports the TextEncoder API natively, since the polyfill won't be used!
-You'd need to fork and modify the polyfill to... not be a polyfill.
+In Order to use this TextEncoder anyway there is a 'CustomTextEncoder' and 'CustomTextDecoder'
+attached.
+
+```js
+var uint8array = new CustomTextEncoder(
+  'windows-1252', { NONSTANDARD_allowLegacyEncoding: true }).encode(text);
+```
 
 To support the legacy encodings (which may be stateful), the TextEncoder `encode()`
 method accepts an optional dictionary and `stream` option,

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -3092,4 +3092,7 @@ if (typeof module !== "undefined" && module.exports) {
     global['TextEncoder'] = TextEncoder;
   if (!global['TextDecoder'])
     global['TextDecoder'] = TextDecoder;
+
+	global['CustomTextEncoder'] = TextEncoder;
+	global['CustomTextDecoder'] = TextDecoder;
 }(this));


### PR DESCRIPTION
Hi Joshua,

I needed a windows-1252 encoder which is working on any browser even if browser alreday implements a TextEncoder. So I read your suggestion to make a non polyfill version. I wondered why not doing a "hybrid"-version. This is the result: I only make the TextEncoder and TextDecoder also globally available as CustomTextEncoder and CustomTextDecoder which is working pretty fine.

In order to make it easy for you to pull (If you like it) I also adopted the readme file.

Best regards,
Oliver
