### PR TITLE
Add valid SPDX license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   "bugs": {
     "url": "https://github.com/inexorabletash/text-encoding/issues"
   },
-  "homepage": "https://github.com/inexorabletash/text-encoding"
+  "homepage": "https://github.com/inexorabletash/text-encoding",
+  "license": "Unlicense"
 }


### PR DESCRIPTION
Adds the "Unlicense" license identifier from https://spdx.org/licenses/. 

See [here](https://github.com/npm/npm/issues/8918) for some interesting background minutes. This should help users which use tools to whitelist packages based on the license identifier in `package.json`, where the `text-encoding` is currently being treated as proprietary software since the license cannot be automatically determined.