### PR TITLE
Performance improvements

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -184,6 +184,7 @@ if (typeof module !== "undefined" && module.exports) {
   function Stream(tokens) {
     /** @type {!Array.<number>} */
     this.tokens = [].slice.call(tokens);
+    this.tokens.reverse();
   }
 
   Stream.prototype = {
@@ -205,7 +206,7 @@ if (typeof module !== "undefined" && module.exports) {
      read: function() {
       if (!this.tokens.length)
         return end_of_stream;
-       return this.tokens.shift();
+       return this.tokens.pop();
      },
 
     /**
@@ -219,9 +220,9 @@ if (typeof module !== "undefined" && module.exports) {
       if (Array.isArray(token)) {
         var tokens = /**@type {!Array.<number>}*/(token);
         while (tokens.length)
-          this.tokens.unshift(tokens.pop());
+          this.tokens.push(tokens.pop());
       } else {
-        this.tokens.unshift(token);
+        this.tokens.push(token);
       }
     },
 
@@ -230,15 +231,15 @@ if (typeof module !== "undefined" && module.exports) {
      * must be inserted, in given order, after the last token in the
      * stream.
      *
-     * @param {(number|!Array.<number>)} token The tokens(s) to prepend to the stream.
+     * @param {(number|!Array.<number>)} token The tokens(s) to push to the stream.
      */
     push: function(token) {
       if (Array.isArray(token)) {
         var tokens = /**@type {!Array.<number>}*/(token);
         while (tokens.length)
-          this.tokens.push(tokens.shift());
+          this.tokens.unshift(tokens.shift());
       } else {
-        this.tokens.push(token);
+        this.tokens.unshift(token);
       }
     }
   };

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1025,9 +1025,9 @@ if (typeof module !== "undefined" && module.exports) {
 
       /** @type {?(number|!Array.<number>)} */
       var result;
-
-      while (!input_stream.endOfStream()) {
-        result = this._decoder.handler(input_stream, input_stream.read());
+      var token;
+      while ((token = input_stream.read()) !== end_of_stream) {  
+        result = this._decoder.handler(input_stream, token);
         if (result === finished)
           break;
         if (result === null)
@@ -1141,8 +1141,9 @@ if (typeof module !== "undefined" && module.exports) {
       var input_stream = new Stream(stringToCodePoints(opt_string));
       /** @type {?(number|!Array.<number>)} */
       var result;
-      while (!input_stream.endOfStream()) {
-        result = this._encoder.handler(input_stream, input_stream.read());
+      var token;
+      while ((token = input_stream.read()) !== end_of_stream) {  
+        result = this._encoder.handler(input_stream, token);
         if (result === finished)
           break;
         if (Array.isArray(result))


### PR DESCRIPTION
For large strings/byte arrays the library becomes unusable. I've made some small changes that improve the performance by 100% to 200%:
  - use pop/push over shift/unshift for the most common Stream methods (read, prepend)
  - remove the call to endOfStream function from encode/decode since read already performs an endOfStream test

The biggest performance improvement comes from changing the Stream implementation.