### PR TITLE
corrects stringToCodePoint function

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -98,7 +98,7 @@ if (typeof module !== "undefined" && module.exports) {
         // 2. Otherwise, i < n−1:
         else {
           // 1. Let d be the code unit in S at index i+1.
-          var d = string.charCodeAt(i + 1);
+          var d = s.charCodeAt(i + 1);
 
           // 2. If 0xDC00 ≤ d ≤ 0xDFFF, then:
           if (0xDC00 <= d && d <= 0xDFFF) {


### PR DESCRIPTION
Gets second code unit not from original string but from `s` which is String(originalString). It's like in the specification.