### PR TITLE
Don't expect encoding-indexes to return object with indexes & don't require them if they are already present

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -6,7 +6,8 @@
  * @fileoverview Global |this| required for resolving indexes in node.
  * @suppress {globalThis}
  */
-if (typeof module !== "undefined" && module.exports) {
+if (typeof module !== "undefined" && module.exports &&
+    !this["encoding-indexes"]) {
   this["encoding-indexes"] =
     require("./encoding-indexes.js")["encoding-indexes"];
 }

--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -8,8 +8,7 @@
  */
 if (typeof module !== "undefined" && module.exports &&
     !this["encoding-indexes"]) {
-  this["encoding-indexes"] =
-    require("./encoding-indexes.js")["encoding-indexes"];
+    require("./encoding-indexes.js");
 }
 
 (function(global) {


### PR DESCRIPTION
Intended to fix #60.