### PR TITLE
Recovered property accessor in encoding.js

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -11,7 +11,8 @@
   // If we're in node require encoding-indexes and attach it to the global.
   if (typeof module !== "undefined" && module.exports &&
     !global["encoding-indexes"]) {
-    global['encoding-indexes'] = require("./encoding-indexes.js");
+    global["encoding-indexes"] =
+      require("./encoding-indexes.js")["encoding-indexes"];
   }
 
   //


### PR DESCRIPTION
Fixed issue described in inexorabletash/text-encoding/issues/67
The problem was casued by the missing propery accessor on the
require statement, which passed the entire global scope of
`encoding-indexes` instead of the indexes.

Short before and after image: http://i.imgur.com/4XrpKiJ.png